### PR TITLE
feat(top-posts): add top 5 posts on Landing Page

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -4,7 +4,7 @@ from .models import Post, Category, Tag
 
 @admin.register(Post)
 class PostAdmin(admin.ModelAdmin):
-    list_display = ('title', 'publish_date', 'category')
+    list_display = ('title', 'publish_date', 'category', 'likes')
     search_fields = ('title', 'content')
     list_filter = ('category', 'publish_date')
     ordering = ('-publish_date',)

--- a/blog/models.py
+++ b/blog/models.py
@@ -20,6 +20,7 @@ class Post(models.Model):
     category = models.ForeignKey(Category, on_delete=models.CASCADE, related_name='posts') 
     tags = models.ManyToManyField('Tag', blank=True, related_name='posts')
     publish_date = models.DateTimeField(default=timezone.now)
+    likes = models.PositiveIntegerField(default=0)
     def __str__(self):
         return self.title
     

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,5 +1,13 @@
 from django.shortcuts import render
-from django.http import HttpResponse
+from .models import Post
+from django.http import JsonResponse
 
 def home(request):
-    return HttpResponse("Hello, this is the homepage!")
+    top_posts = Post.objects.order_by('-likes', '-publish_date')[:5]
+    
+    #Uncomment the following line to render a template when adding the frontend and comment the JsonResponse
+    # return render(request, 'home.html', {'top_posts': top_posts})
+
+    #for testing as there's no frontend yet (you have to remove it or comment it when you add the frontend)
+    data = [{"title": post.title, "likes": post.likes, "date": post.publish_date} for post in top_posts]
+    return JsonResponse(data, safe=False)


### PR DESCRIPTION
Added the following features to landing page:
  - Add Likes field to models.
  - Order the top 5 posts with their likes count (DESC).
  - Retrieve the posts as json on the home page as there's no frontend yet.

Closes #19